### PR TITLE
Fix CORS wildcard pattern matching for dynamic Vercel URLs

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -5,8 +5,13 @@ NODE_ENV=development
 # External APIs
 POKEAPI_BASE_URL=https://pokeapi.co/api/v2
 
-# CORS Configuration
+# CORS Configuration (supports wildcard patterns)
+# Development:
 CORS_ORIGIN=http://localhost:3000
+# Production examples:
+# CORS_ORIGIN=https://*.vercel.app
+# CORS_ORIGIN=https://*-coffmanjrps-projects.vercel.app
+# CORS_ORIGIN=https://*.vercel.app,http://localhost:3000
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379
@@ -18,5 +23,8 @@ REDIS_PASSWORD=
 # Set these in Railway Dashboard:
 # PORT=4000 (automatically set by Railway)
 # NODE_ENV=production
-# CORS_ORIGIN=http://localhost:3000,https://pokemon-pokedex-coral.vercel.app,https://pokemon-pokedex-git-feature-hybrid-deployment-setup-coffmanjrp.vercel.app
+# CORS_ORIGIN=https://*.vercel.app (recommended for Vercel deployments)
+# Alternative specific patterns:
+# CORS_ORIGIN=https://*-coffmanjrps-projects.vercel.app
+# CORS_ORIGIN=https://pokemon-pokedex-*-coffmanjrps-projects.vercel.app
 # REDIS_URL=redis://railway-redis-url (provided by Railway Redis add-on)


### PR DESCRIPTION
## Summary
- CORS設定にワイルドカードパターンマッチング機能を実装
- 動的に生成されるVercel URLに対応
- `https://*.vercel.app`パターンで全てのVercel deploymentをサポート

## Changes
- `isOriginAllowed()`関数を追加してregexベースのパターンマッチングを実装
- `*`を`.*`に変換、ドットを適切にエスケープ
- 詳細なCORSデバッグログを追加
- `.env.example`にワイルドカードパターンの例を追加

## Test plan
- [ ] Railway環境変数`CORS_ORIGIN=https://*.vercel.app`を設定
- [ ] Vercelフロントエンドからの接続をテスト
- [ ] 動的URLパターンでの接続確認

🤖 Generated with [Claude Code](https://claude.ai/code)