### PR TITLE
Fix Pokemon genus display issue with fallback support

### DIFF
--- a/client/lib/pokemonUtils.ts
+++ b/client/lib/pokemonUtils.ts
@@ -530,11 +530,32 @@ export function getPokemonDescription(
 }
 
 /**
+ * Get fallback genus text for the specified language
+ */
+function getGenusFallback(language: Locale): string {
+  const fallbackTexts: Record<Locale, string> = {
+    en: "Pokémon",
+    ja: "ポケモン",
+    "zh-Hant": "寶可夢",
+    "zh-Hans": "宝可梦",
+    es: "Pokémon",
+    ko: "포켓몬",
+    fr: "Pokémon",
+    it: "Pokémon",
+    de: "Pokémon",
+  };
+
+  return fallbackTexts[language] || "Pokémon";
+}
+
+/**
  * Get Pokemon genus (category) in the specified language
  */
 export function getPokemonGenus(pokemon: Pokemon, language: Locale): string {
-  if (!pokemon.species?.genera) {
-    return "";
+  // Check if genus data exists
+  if (!pokemon.species?.genera || pokemon.species.genera.length === 0) {
+    // Return fallback text instead of empty string
+    return getGenusFallback(language);
   }
 
   // Map locale to PokeAPI language codes
@@ -556,7 +577,8 @@ export function getPokemonGenus(pokemon: Pokemon, language: Locale): string {
     targetCodes.includes(genusEntry.language.name),
   );
 
-  return genus?.genus || "";
+  // Return genus or fallback text
+  return genus?.genus || getGenusFallback(language);
 }
 
 /**

--- a/server/src/services/pokemonService.ts
+++ b/server/src/services/pokemonService.ts
@@ -299,7 +299,15 @@ class PokemonService {
         })),
         genderRate: speciesData.gender_rate ?? 4, // Default to 50/50 ratio if not available
         hasGenderDifferences: speciesData.has_gender_differences ?? false,
-      } : null,
+      } : {
+        // Return minimal species object with empty arrays when species data is not available
+        id: data.id.toString(),
+        name: data.name,
+        names: [],
+        genera: [],
+        genderRate: 4, // Default to 50/50 ratio
+        hasGenderDifferences: false,
+      },
     };
   }
 
@@ -373,13 +381,13 @@ class PokemonService {
             url: entry.version.url,
           },
         })),
-        genera: speciesData.genera.map((genus: any) => ({
+        genera: speciesData.genera ? speciesData.genera.map((genus: any) => ({
           genus: genus.genus,
           language: {
             name: genus.language.name,
             url: genus.language.url,
           },
-        })),
+        })) : [],
         generation: {
           id: this.extractIdFromUrl(speciesData.generation.url),
           name: speciesData.generation.name,
@@ -389,7 +397,18 @@ class PokemonService {
         hasGenderDifferences: speciesData.has_gender_differences ?? false,
         evolutionChain: speciesData.evolution_chain ? 
           await this.getEvolutionChain(speciesData.evolution_chain.url) : undefined,
-      } : null,
+      } : {
+        // Return minimal species object with empty arrays when species data is not available
+        id: data.id.toString(),
+        name: data.name,
+        names: [],
+        flavorTextEntries: [],
+        genera: [],
+        generation: null,
+        genderRate: 4, // Default to 50/50 ratio
+        hasGenderDifferences: false,
+        evolutionChain: undefined,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary
- Fix issue where some Pokemon cards don't display genus (classification) text
- Add multi-language fallback support when genus data is missing
- Improve backend data handling for consistent display

## Problem
Some Pokemon cards were not showing genus information (e.g., "たねポケモン", "おたまポケモン") while others displayed correctly. This was particularly noticeable with Generation V (Unova) Pokemon.

## Solution
### Frontend Changes
- Added `getGenusFallback()` function to provide "Pokémon" text in all 9 supported languages
- Updated `getPokemonGenus()` to return fallback text instead of empty string when data is missing
- Ensures all Pokemon cards show at least "ポケモン" (or localized equivalent) as genus

### Backend Changes  
- Modified `transformPokemonData()` and `transformPokemonBasicData()` to return minimal species object instead of null
- Ensures species.genera is always an array (empty if no data available)
- Prevents null reference errors in frontend

## Fallback Support
Fallback text for all 9 languages:
- English: "Pokémon"
- Japanese: "ポケモン"
- Traditional Chinese: "寶可夢"
- Simplified Chinese: "宝可梦"
- Spanish: "Pokémon"
- Korean: "포켓몬"
- French: "Pokémon"
- Italian: "Pokémon"
- German: "Pokémon"

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Verify genus displays for all Pokemon generations
- [x] Confirm fallback text appears when genus data is missing
- [x] Test in multiple languages to ensure proper localization

## Screenshots
Before: Some Pokemon cards showed empty space where genus should be
After: All Pokemon cards display either specific genus or "Pokémon" fallback

🤖 Generated with [Claude Code](https://claude.ai/code)