### PR TITLE
Fix undefined edges error in usePokemonList hook

### DIFF
--- a/client/hooks/usePokemonList.ts
+++ b/client/hooks/usePokemonList.ts
@@ -364,6 +364,14 @@ export function usePokemonList({
             return previousResult;
           }
 
+          // Ensure previousData exists and has edges array
+          if (!previousData || !previousData.edges) {
+            return {
+              ...previousResult,
+              [fieldName]: newData,
+            };
+          }
+
           // Filter new Pokemon to only include those in current generation
           const filteredEdges = newData.edges.filter((edge: PokemonEdge) => {
             const pokemonId = parseInt(edge.node.id);


### PR DESCRIPTION
## Summary

Fix runtime error in Pokemon list loading when `previousData.edges` is undefined.

## Problem

Console error was occurring:
```
Error: Cannot read properties of undefined (reading 'edges')
hooks/usePokemonList.ts (380:39)
```

This happened during initial Pokemon list loading and generation switching when `previousData` or `previousData.edges` was undefined.

## Solution

- Add safety check for `previousData` and `previousData.edges` existence
- Handle initial state when no previous Pokemon data exists
- Return new data directly if no previous edges exist
- Maintain existing merge behavior when previous data is available

## Changes Made

### usePokemonList.ts
- Added null/undefined guard clause before accessing `previousData.edges`
- Implemented proper fallback behavior for initial data loading
- Enhanced error handling during Pokemon list fetching and generation switching

## Test plan

- [x] Pokemon list loads without console errors on initial load
- [x] Generation switching works properly without undefined errors
- [x] Existing Pokemon list merge functionality preserved
- [x] TypeScript compilation passes without errors
- [x] Pre-commit hooks pass (linting, formatting, type checking)

🤖 Generated with [Claude Code](https://claude.ai/code)