### PR TITLE
feat: add copyright disclaimer and Chinese language support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,9 @@ pokemon-pokedex/
 ### Feature Details
 @docs/FEATURES.md
 
+### Language Implementation
+@docs/LANGUAGE_IMPLEMENTATION.md
+
 
 
 ## Common Issues & Solutions
@@ -257,6 +260,10 @@ For more solutions, see documentation in `/docs`
 34. ✅ Added footer to Pokemon detail pages with consistent styling
 35. ✅ Added tagline under logo indicating unofficial fan-made database
 36. ✅ Fixed TypeScript type definitions for tagline property
+37. ✅ Re-implemented Chinese language support (zh-Hans and zh-Hant)
+38. ✅ Added User-Agent detection for Chinese browsers
+39. ✅ Updated Pokemon data functions to support Chinese localization
+40. ✅ Created comprehensive language implementation documentation
 
 ### Next Steps & TODOs
 

--- a/client/app/[lang]/layout.tsx
+++ b/client/app/[lang]/layout.tsx
@@ -2,7 +2,12 @@ import { Locale } from "@/lib/dictionaries";
 import ConditionalLayout from "./ConditionalLayout";
 
 export async function generateStaticParams() {
-  return [{ lang: "en" }, { lang: "ja" }];
+  return [
+    { lang: "en" },
+    { lang: "ja" },
+    { lang: "zh-Hans" },
+    { lang: "zh-Hant" },
+  ];
 }
 
 interface LangLayoutProps {

--- a/client/app/[lang]/pokemon/[id]/page.tsx
+++ b/client/app/[lang]/pokemon/[id]/page.tsx
@@ -32,7 +32,7 @@ interface PokemonDetailPageProps {
 // Generate static params for SSG with generational build support
 export async function generateStaticParams() {
   const paths = [];
-  const languages = ["en", "ja"];
+  const languages = ["en", "ja", "zh-Hans", "zh-Hant"];
 
   // Check environment variables for generational build control
   const enableGenerationalBuild =

--- a/client/lib/data/languages.ts
+++ b/client/lib/data/languages.ts
@@ -21,4 +21,6 @@ export interface LanguageLabels {
 export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { value: "en", labelKey: "english", flag: "🇺🇸" },
   { value: "ja", labelKey: "japanese", flag: "🇯🇵" },
+  { value: "zh-Hans", labelKey: "simplifiedChinese", flag: "🇨🇳" },
+  { value: "zh-Hant", labelKey: "traditionalChinese", flag: "🇹🇼" },
 ];

--- a/client/lib/dictionaries.ts
+++ b/client/lib/dictionaries.ts
@@ -1,4 +1,4 @@
-export type Locale = "en" | "ja";
+export type Locale = "en" | "ja" | "zh-Hans" | "zh-Hant";
 
 // Dictionary type definition
 export interface Dictionary {
@@ -489,7 +489,9 @@ export interface Dictionary {
 export const getLocaleFromPathname = (pathname: string): Locale => {
   const segments = pathname.split("/");
   const locale = segments[1] as Locale;
-  return locale && ["en", "ja"].includes(locale) ? locale : "en";
+  return locale && ["en", "ja", "zh-Hans", "zh-Hant"].includes(locale)
+    ? locale
+    : "en";
 };
 
 export const generateAlternateLanguageUrl = (
@@ -499,7 +501,10 @@ export const generateAlternateLanguageUrl = (
   const segments = pathname.split("/");
   const currentLocale = segments[1];
 
-  if (currentLocale && ["en", "ja"].includes(currentLocale)) {
+  if (
+    currentLocale &&
+    ["en", "ja", "zh-Hans", "zh-Hant"].includes(currentLocale)
+  ) {
     segments[1] = newLocale;
     return segments.join("/");
   }

--- a/client/lib/dictionaries/zh-Hans.json
+++ b/client/lib/dictionaries/zh-Hans.json
@@ -71,10 +71,18 @@
       "tryAgain": "重试",
       "pokemonNotFound": "找不到宝可梦",
       "goHome": "返回首页",
-      "unknown": "未知"
+      "unknown": "未知",
+      "evolutionChainError": "进化数据加载错误",
+      "movesError": "招式数据加载错误",
+      "genericError": "发生错误",
+      "networkError": "网络错误",
+      "serverError": "服务器错误",
+      "notFoundError": "资源未找到",
+      "validationError": "提供的数据无效"
     },
     "common": {
-      "loading": "加载中"
+      "loading": "加载中",
+      "tagline": "非官方宝可梦数据库"
     },
     "notFound": {
       "title": "找不到宝可梦",
@@ -247,6 +255,7 @@
       "games": "无游戏数据",
       "sprites": "无图像可用",
       "evolution": "无进化数据",
+      "evolutionSoon": "进化数据即将推出",
       "abilities": "无特性数据",
       "general": "无数据可用"
     },
@@ -443,8 +452,9 @@
   "meta": {
     "title": "宝可梦图鉴",
     "description": "完整的宝可梦图鉴，包含所有世代的宝可梦详细信息、属性、能力值和进化链。",
-    "homeTitle": "宝可梦图鉴 - 探索所有世代的宝可梦",
-    "homeDescription": "浏览完整的宝可梦图鉴，查看来自所有世代的宝可梦详细信息、属性、能力值、招式和进化链。",
+    "homeTitle": "非官方宝可梦图鉴 | 完整的多世代宝可梦数据库",
+    "homeDescription": "非官方的综合性宝可梦数据库，收录1302+只宝可梦的详细数据、官方插图、属性相克、进化链和招式表。涵盖第1至第9世代的完整内容。这是一个粉丝制作的网站，与任天堂无关。",
+    "listDescription": "浏览{{region}}地区的所有宝可梦。按属性筛选，按名称搜索，探索每只宝可梦的详细信息，包括能力值、进化链和招式。",
     "pokemonTitle": "{{name}} - 宝可梦图鉴",
     "pokemonDescription": "查看{{name}}的详细信息，包括属性、能力值、招式、进化链和更多内容。",
     "pokemonDescriptionShort": "{{name}}的完整宝可梦信息。",
@@ -453,5 +463,11 @@
     "pokemonImageAlt": "{{name}} - 宝可梦图鉴",
     "fallbackImageAlt": "宝可梦图鉴 - 完整的宝可梦数据库",
     "locale": "zh_CN"
+  },
+  "footer": {
+    "copyright": "宝可梦 © 1995-{{currentYear}} Nintendo/Creatures Inc./GAME FREAK inc.",
+    "trademark": "宝可梦和宝可梦角色名称是任天堂的商标。",
+    "disclaimer": "这是一个非官方的、非商业性的粉丝网站，与任天堂、Creatures Inc.或GAME FREAK inc.无关。",
+    "dataSource": "数据来源："
   }
 }

--- a/client/lib/dictionaries/zh-Hant.json
+++ b/client/lib/dictionaries/zh-Hant.json
@@ -71,10 +71,18 @@
       "tryAgain": "重試",
       "pokemonNotFound": "找不到寶可夢",
       "goHome": "返回首頁",
-      "unknown": "未知"
+      "unknown": "未知",
+      "evolutionChainError": "進化資料載入錯誤",
+      "movesError": "招式資料載入錯誤",
+      "genericError": "發生錯誤",
+      "networkError": "網路錯誤",
+      "serverError": "伺服器錯誤",
+      "notFoundError": "資源未找到",
+      "validationError": "提供的資料無效"
     },
     "common": {
-      "loading": "載入中"
+      "loading": "載入中",
+      "tagline": "非官方寶可夢資料庫"
     },
     "notFound": {
       "title": "找不到寶可夢",
@@ -247,6 +255,7 @@
       "games": "無遊戲數據",
       "sprites": "無圖像可用",
       "evolution": "無進化數據",
+      "evolutionSoon": "進化資料即將推出",
       "abilities": "無特性數據",
       "general": "無數據可用"
     },
@@ -443,8 +452,9 @@
   "meta": {
     "title": "寶可夢圖鑑",
     "description": "完整的寶可夢圖鑑，包含所有世代的寶可夢詳細資訊、屬性、能力值和進化鏈。",
-    "homeTitle": "寶可夢圖鑑 - 探索所有世代的寶可夢",
-    "homeDescription": "瀏覽完整的寶可夢圖鑑，查看來自所有世代的寶可夢詳細資訊、屬性、能力值、招式和進化鏈。",
+    "homeTitle": "非官方寶可夢圖鑑 | 完整的多世代寶可夢資料庫",
+    "homeDescription": "非官方的綜合性寶可夢資料庫，收錄1302+隻寶可夢的詳細資料、官方插圖、屬性相剋、進化鏈和招式表。涵蓋第1至第9世代的完整內容。這是一個粉絲製作的網站，與任天堂無關。",
+    "listDescription": "瀏覽{{region}}地區的所有寶可夢。按屬性篩選，按名稱搜尋，探索每隻寶可夢的詳細資訊，包括能力值、進化鏈和招式。",
     "pokemonTitle": "{{name}} - 寶可夢圖鑑",
     "pokemonDescription": "查看{{name}}的詳細資訊，包括屬性、能力值、招式、進化鏈和更多內容。",
     "pokemonDescriptionShort": "{{name}}的完整寶可夢資訊。",
@@ -453,5 +463,11 @@
     "pokemonImageAlt": "{{name}} - 寶可夢圖鑑",
     "fallbackImageAlt": "寶可夢圖鑑 - 完整的寶可夢資料庫",
     "locale": "zh_TW"
+  },
+  "footer": {
+    "copyright": "寶可夢 © 1995-{{currentYear}} Nintendo/Creatures Inc./GAME FREAK inc.",
+    "trademark": "寶可夢和寶可夢角色名稱是任天堂的商標。",
+    "disclaimer": "這是一個非官方的、非商業性的粉絲網站，與任天堂、Creatures Inc.或GAME FREAK inc.無關。",
+    "dataSource": "資料來源："
   }
 }

--- a/client/lib/get-dictionary.ts
+++ b/client/lib/get-dictionary.ts
@@ -4,6 +4,10 @@ import { Dictionary, Locale } from "./dictionaries";
 const dictionaries = {
   en: () => import("./dictionaries/en.json").then((module) => module.default),
   ja: () => import("./dictionaries/ja.json").then((module) => module.default),
+  "zh-Hans": () =>
+    import("./dictionaries/zh-Hans.json").then((module) => module.default),
+  "zh-Hant": () =>
+    import("./dictionaries/zh-Hant.json").then((module) => module.default),
 };
 
 export const getDictionary = async (locale: Locale): Promise<Dictionary> => {

--- a/client/lib/languageStorage.ts
+++ b/client/lib/languageStorage.ts
@@ -1,4 +1,4 @@
-import { Language } from "@/store/slices/uiSlice";
+import { Locale } from "@/lib/dictionaries";
 
 const LANGUAGE_STORAGE_KEY = "pokemon-pokedex-language";
 const LANGUAGE_COOKIE_KEY = "pokemon-pokedex-lang";
@@ -7,14 +7,20 @@ const LANGUAGE_COOKIE_KEY = "pokemon-pokedex-lang";
  * Get stored language preference from localStorage
  * Returns null if not available or not supported
  */
-export function getStoredLanguage(): Language | null {
+export function getStoredLanguage(): Locale | null {
   // Check if we're on the client side
   if (typeof window === "undefined") return null;
 
   try {
     const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
-    if (stored && (stored === "en" || stored === "ja")) {
-      return stored as Language;
+    if (
+      stored &&
+      (stored === "en" ||
+        stored === "ja" ||
+        stored === "zh-Hans" ||
+        stored === "zh-Hant")
+    ) {
+      return stored as Locale;
     }
   } catch (error) {
     // localStorage might not be available (e.g., in private mode)
@@ -30,7 +36,7 @@ export function getStoredLanguage(): Language | null {
 /**
  * Save language preference to localStorage and cookie
  */
-export function setStoredLanguage(language: Language): void {
+export function setStoredLanguage(language: Locale): void {
   // Check if we're on the client side
   if (typeof window === "undefined") return;
 
@@ -66,7 +72,7 @@ export function clearStoredLanguage(): void {
 /**
  * Get language preference from cookie (for server-side access)
  */
-export function getLanguageFromCookie(cookieString: string): Language | null {
+export function getLanguageFromCookie(cookieString: string): Locale | null {
   const cookies = cookieString.split(";").map((c) => c.trim());
   const languageCookie = cookies.find((c) =>
     c.startsWith(`${LANGUAGE_COOKIE_KEY}=`),
@@ -74,8 +80,13 @@ export function getLanguageFromCookie(cookieString: string): Language | null {
 
   if (languageCookie) {
     const value = languageCookie.split("=")[1];
-    if (value === "en" || value === "ja") {
-      return value as Language;
+    if (
+      value === "en" ||
+      value === "ja" ||
+      value === "zh-Hans" ||
+      value === "zh-Hant"
+    ) {
+      return value as Locale;
     }
   }
 

--- a/client/lib/pokemonUtils.ts
+++ b/client/lib/pokemonUtils.ts
@@ -25,7 +25,7 @@ function getFormTranslation(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _formName: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _language: "en" | "ja",
+  _language: Locale,
 ): string | null {
   // Special forms now handled by dictionary system
   // This function is deprecated and should use dictionary lookup instead

--- a/client/lib/pokemonUtils.ts
+++ b/client/lib/pokemonUtils.ts
@@ -210,9 +210,14 @@ export function getPokemonName(
     const formName = nameParts.slice(1).join("-");
 
     // Use species data for localized names
-    if (language === "ja" && pokemon.species?.names) {
+    if (
+      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      pokemon.species?.names
+    ) {
       const languageCodes = {
         ja: ["ja", "ja-Hrkt"],
+        "zh-Hans": ["zh-Hans"],
+        "zh-Hant": ["zh-Hant"],
       };
 
       const targetCodes = languageCodes[
@@ -288,10 +293,15 @@ export function getPokemonName(
     const formName = nameParts.slice(1).join("-");
 
     // Handle non-English languages with species names
-    if (language === "ja" && pokemon.species?.names) {
+    if (
+      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      pokemon.species?.names
+    ) {
       // Map language codes for PokeAPI
       const languageCodes = {
         ja: ["ja", "ja-Hrkt"],
+        "zh-Hans": ["zh-Hans"],
+        "zh-Hant": ["zh-Hant"],
       };
 
       const targetCodes = languageCodes[
@@ -390,10 +400,15 @@ export function getPokemonName(
   }
 
   // For non-variant Pokemon
-  if (language === "ja" && pokemon.species?.names) {
+  if (
+    (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+    pokemon.species?.names
+  ) {
     // Map language codes for PokeAPI
     const languageCodes = {
       ja: ["ja", "ja-Hrkt"],
+      "zh-Hans": ["zh-Hans"],
+      "zh-Hant": ["zh-Hant"],
     };
 
     const targetCodes = languageCodes[
@@ -429,10 +444,15 @@ export function getEvolutionPokemonName(
     const formName = nameParts.slice(1).join("-");
 
     // Handle non-English languages with species names
-    if (language === "ja" && evolutionDetail.species?.names) {
+    if (
+      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      evolutionDetail.species?.names
+    ) {
       // Map language codes for PokeAPI
       const languageCodes = {
         ja: ["ja", "ja-Hrkt"],
+        "zh-Hans": ["zh-Hans"],
+        "zh-Hant": ["zh-Hant"],
       };
 
       const targetCodes = languageCodes[
@@ -490,10 +510,15 @@ export function getEvolutionPokemonName(
   }
 
   // For non-variant Pokemon
-  if (language === "ja" && evolutionDetail.species?.names) {
+  if (
+    (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+    evolutionDetail.species?.names
+  ) {
     // Map language codes for PokeAPI
     const languageCodes = {
       ja: ["ja", "ja-Hrkt"],
+      "zh-Hans": ["zh-Hans"],
+      "zh-Hant": ["zh-Hant"],
     };
 
     const targetCodes = languageCodes[
@@ -530,6 +555,8 @@ export function getPokemonDescription(
   const languageMap: Record<string, string[]> = {
     en: ["en"],
     ja: ["ja", "ja-Hrkt"],
+    "zh-Hans": ["zh-Hans"],
+    "zh-Hant": ["zh-Hant"],
   };
 
   const targetCodes = languageMap[language] || ["en"];
@@ -568,6 +595,8 @@ function getGenusFallback(language: Locale): string {
   const fallbackTexts: Record<Locale, string> = {
     en: "Pokémon",
     ja: "ポケモン",
+    "zh-Hans": "宝可梦",
+    "zh-Hant": "寶可夢",
   };
 
   return fallbackTexts[language] || "Pokémon";
@@ -587,6 +616,8 @@ export function getPokemonGenus(pokemon: Pokemon, language: Locale): string {
   const languageMap: Record<string, string[]> = {
     en: ["en"],
     ja: ["ja", "ja-Hrkt"],
+    "zh-Hans": ["zh-Hans"],
+    "zh-Hant": ["zh-Hant"],
   };
 
   const targetCodes = languageMap[language] || ["en"];
@@ -1078,6 +1109,8 @@ export function getMoveFlavorText(move: Move, language: Locale): string {
   const languageMap: Record<string, string[]> = {
     en: ["en"],
     ja: ["ja", "ja-Hrkt"],
+    "zh-Hans": ["zh-Hans"],
+    "zh-Hant": ["zh-Hant"],
   };
 
   const targetCodes = languageMap[language] || ["en"];

--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getLanguageFromCookie } from "@/lib/languageStorage";
 
-const locales = ["en", "ja"];
+const locales = ["en", "ja", "zh-Hans", "zh-Hant"];
 const defaultLocale = "en";
 
 // Check User-Agent for language indicators
@@ -30,6 +30,51 @@ function getUserAgentLanguage(request: NextRequest): string | null {
     }
   }
 
+  // Check for Traditional Chinese indicators first (more specific)
+  const traditionalChineseIndicators = [
+    "zh-tw",
+    "zh-hk",
+    "zh-mo",
+    "taiwan",
+    "hong kong",
+    "hongkong",
+    "macau",
+    "繁體",
+    "繁体",
+    "正體",
+    "臺灣",
+    "台灣",
+    "台湾",
+    "香港",
+  ];
+
+  for (const indicator of traditionalChineseIndicators) {
+    if (userAgentLower.includes(indicator.toLowerCase())) {
+      return "zh-Hant";
+    }
+  }
+
+  // Check for Simplified Chinese indicators
+  const simplifiedChineseIndicators = [
+    "zh-cn",
+    "zh-sg",
+    "china",
+    "chinese",
+    "中文",
+    "中国",
+    "简体",
+    "簡體",
+    "大陆",
+    "大陸",
+    "新加坡",
+  ];
+
+  for (const indicator of simplifiedChineseIndicators) {
+    if (userAgentLower.includes(indicator.toLowerCase())) {
+      return "zh-Hans";
+    }
+  }
+
   return null;
 }
 
@@ -50,7 +95,7 @@ function getLocale(request: NextRequest): string {
     return cookieLang;
   }
 
-  // 2. Check User-Agent for Japanese detection
+  // 2. Check User-Agent for language detection (Japanese, Chinese)
   const userAgentLang = getUserAgentLanguage(request);
   if (userAgentLang && locales.includes(userAgentLang)) {
     return userAgentLang;

--- a/docs/LANGUAGE_IMPLEMENTATION.md
+++ b/docs/LANGUAGE_IMPLEMENTATION.md
@@ -1,0 +1,265 @@
+# Language Implementation Guide
+
+This guide documents the process of adding new language support to the Pokemon Pokedex application, based on the Chinese language implementation completed on 2025-07-22.
+
+## Overview
+
+The application supports multiple languages through:
+1. **UI Translations**: Static text in dictionary JSON files
+2. **Pokemon Data**: Dynamic data from Supabase (originally from PokeAPI)
+3. **Middleware**: Automatic language detection and routing
+
+## Prerequisites
+
+Before adding a new language:
+1. Verify the language is supported by PokeAPI: https://pokeapi.co/api/v2/language/
+2. Identify the PokeAPI language code (e.g., "ko" for Korean, "es" for Spanish)
+3. Prepare comprehensive UI translations (400+ strings)
+
+## Implementation Steps
+
+### 1. Create Language Dictionary File
+
+Create `client/lib/dictionaries/[lang].json` with all UI translations. Copy an existing dictionary (e.g., `en.json`) as a template:
+
+```bash
+cp client/lib/dictionaries/en.json client/lib/dictionaries/[lang].json
+```
+
+Key sections to translate:
+- `common`: App name, navigation, general UI text
+- `pokemonTypes`: All 18 Pokemon type names
+- `pokemonDetails`: Detail page labels
+- `stats`: Pokemon stat names
+- `error`: Error messages
+- `emptyStates`: Empty state messages
+- `meta`: SEO metadata
+- `forms`: Pokemon form names
+- `tagline`: Unofficial site notice
+- `footer`: Copyright and disclaimer
+
+### 2. Update Type Definitions
+
+Edit `client/lib/dictionaries.ts`:
+
+```typescript
+export type Locale = "en" | "ja" | "zh-Hans" | "zh-Hant" | "[new-lang]";
+```
+
+### 3. Update Dictionary Loader
+
+Edit `client/lib/get-dictionary.ts`:
+
+```typescript
+const dictionaries = {
+  en: () => import('./dictionaries/en.json').then((module) => module.default),
+  ja: () => import('./dictionaries/ja.json').then((module) => module.default),
+  "zh-Hans": () => import('./dictionaries/zh-Hans.json').then((module) => module.default),
+  "zh-Hant": () => import('./dictionaries/zh-Hant.json').then((module) => module.default),
+  "[new-lang]": () => import('./dictionaries/[new-lang].json').then((module) => module.default),
+};
+```
+
+### 4. Update Middleware
+
+Edit `client/middleware.ts`:
+
+```typescript
+const locales = ["en", "ja", "zh-Hans", "zh-Hant", "[new-lang]"];
+```
+
+Optional: Add User-Agent detection for automatic language selection:
+
+```typescript
+// In getUserAgentLanguage function
+const [newLang]Indicators = [
+  "[lang-code]",
+  "[country]",
+  "[native-name]",
+  // Add relevant indicators
+];
+
+for (const indicator of [newLang]Indicators) {
+  if (userAgentLower.includes(indicator.toLowerCase())) {
+    return "[new-lang]";
+  }
+}
+```
+
+### 5. Update Language Options
+
+Edit `client/lib/data/languages.ts`:
+
+```typescript
+export const LANGUAGE_OPTIONS: LanguageOption[] = [
+  { value: "en", labelKey: "english", flag: "🇺🇸" },
+  { value: "ja", labelKey: "japanese", flag: "🇯🇵" },
+  { value: "zh-Hans", labelKey: "simplifiedChinese", flag: "🇨🇳" },
+  { value: "zh-Hant", labelKey: "traditionalChinese", flag: "🇹🇼" },
+  { value: "[new-lang]", labelKey: "[languageLabelKey]", flag: "[flag-emoji]" },
+];
+```
+
+Add the language label key to `LanguageLabels` interface in the same file.
+
+### 6. Update Static Generation
+
+Update all `generateStaticParams` functions to include the new language:
+
+1. `client/app/[lang]/layout.tsx`
+2. `client/app/[lang]/pokemon/[id]/page.tsx`
+
+```typescript
+export async function generateStaticParams() {
+  return [
+    { lang: "en" }, 
+    { lang: "ja" }, 
+    { lang: "zh-Hans" }, 
+    { lang: "zh-Hant" },
+    { lang: "[new-lang]" }
+  ];
+}
+```
+
+### 7. Update Language Storage
+
+Edit `client/lib/languageStorage.ts` to include the new language in validation:
+
+```typescript
+// In getStoredLanguage function
+if (stored && (stored === "en" || stored === "ja" || stored === "zh-Hans" || stored === "zh-Hant" || stored === "[new-lang]")) {
+  return stored as Locale;
+}
+
+// In getLanguageFromCookie function
+if (value === "en" || value === "ja" || value === "zh-Hans" || value === "zh-Hant" || value === "[new-lang]") {
+  return value as Locale;
+}
+```
+
+### 8. Update Pokemon Data Functions
+
+The following functions in `client/lib/pokemonUtils.ts` need to be updated to support the new language:
+
+#### getPokemonName
+```typescript
+const languageCodes = {
+  ja: ["ja", "ja-Hrkt"],
+  "zh-Hans": ["zh-Hans"],
+  "zh-Hant": ["zh-Hant"],
+  "[new-lang]": ["[pokeapi-lang-code]"],
+};
+```
+
+Add condition to check for the new language:
+```typescript
+if ((language === "ja" || language === "zh-Hans" || language === "zh-Hant" || language === "[new-lang]") && pokemon.species?.names) {
+```
+
+#### getPokemonDescription
+```typescript
+const languageMap: Record<string, string[]> = {
+  en: ["en"],
+  ja: ["ja", "ja-Hrkt"],
+  "zh-Hans": ["zh-Hans"],
+  "zh-Hant": ["zh-Hant"],
+  "[new-lang]": ["[pokeapi-lang-code]"],
+};
+```
+
+#### getPokemonGenus
+Same pattern as getPokemonDescription.
+
+#### getEvolutionPokemonName
+Same pattern as getPokemonName - update both variant and non-variant sections.
+
+#### getMoveFlavorText
+Same pattern as getPokemonDescription.
+
+#### getGenusFallback
+```typescript
+const fallbackTexts: Record<Locale, string> = {
+  en: "Pokémon",
+  ja: "ポケモン",
+  "zh-Hans": "宝可梦",
+  "zh-Hant": "寶可夢",
+  "[new-lang]": "[localized-pokemon]",
+};
+```
+
+### 9. Update All Dictionary Files
+
+Add the new language option to the languages section in ALL dictionary files:
+
+```json
+"languages": {
+  "en": "English",
+  "ja": "日本語",
+  "simplifiedChinese": "简体中文",
+  "traditionalChinese": "繁體中文",
+  "[languageLabelKey]": "[Native Language Name]"
+}
+```
+
+### 10. Type Check and Test
+
+Run type checking to ensure all changes are valid:
+
+```bash
+npm run type-check
+```
+
+## Testing Checklist
+
+- [ ] Language switcher shows new language option
+- [ ] UI text displays correctly in new language
+- [ ] Pokemon names load in new language
+- [ ] Pokemon descriptions show in new language
+- [ ] Pokemon genus (classification) shows in new language
+- [ ] Evolution chain names are translated
+- [ ] Move tooltips show translated descriptions
+- [ ] Type names are translated
+- [ ] URLs work correctly (`/[lang]/pokemon/25`)
+- [ ] Middleware detects language correctly
+- [ ] Build completes successfully
+
+## Data Availability Note
+
+Pokemon data translations depend on what's available in PokeAPI. Not all languages have complete data for:
+- Pokemon names (species names)
+- Pokemon descriptions (flavor text)
+- Pokemon genus (classification)
+- Move descriptions
+
+The application will fall back to English when translations are missing.
+
+## Build Impact
+
+Adding languages increases build time and number of static pages:
+
+| Languages | Pages | Build Time |
+|-----------|-------|------------|
+| 2 (current) | 2,786 | ~3m 45s |
+| 3 (+1) | 4,179 | ~5m 30s |
+| 4 (+2) | 5,572 | ~7m 15s |
+
+Consider build time impact before adding many languages.
+
+## Common Issues
+
+1. **TypeScript Errors**: Ensure all type definitions are updated
+2. **Missing Translations**: Some Pokemon data may not be available in all languages
+3. **Build Failures**: Check that all generateStaticParams functions are updated
+4. **Middleware Issues**: Verify language detection logic is correct
+
+## Example: Korean Language Addition
+
+Here's a quick example of adding Korean language support:
+
+1. Create `ko.json` dictionary
+2. Update `Locale` type: `"en" | "ja" | "zh-Hans" | "zh-Hant" | "ko"`
+3. Add to middleware locales: `["en", "ja", "zh-Hans", "zh-Hant", "ko"]`
+4. Update all Pokemon data functions with `ko: ["ko"]`
+5. Add language option: `{ value: "ko", labelKey: "korean", flag: "🇰🇷" }`
+6. Update static generation arrays
+7. Run type check and test


### PR DESCRIPTION
## Summary
- ✨ Add copyright disclaimers and unofficial site notices throughout the application
- 🌏 Implement Chinese language support (Simplified and Traditional)
- 🐛 Fix Poliwag evolution chain display issue

## Changes

### Copyright & Disclaimers
- Add `CopyrightNotice` component in sidebar with dynamic year
- Add `DetailPageFooter` component for Pokemon detail pages
- Add tagline under logo: "Unofficial fan-made Pokémon database"
- Update all dictionary files with copyright and disclaimer translations

### Chinese Language Support
- Add zh-Hans (Simplified Chinese) and zh-Hant (Traditional Chinese) dictionaries
- Update type definitions to include new locales
- Add User-Agent detection for Chinese browsers in middleware
- Update all Pokemon data utility functions to support Chinese
- Update language switcher and routing components

### Bug Fixes
- Fix 3-stage evolution chain display (e.g., Poliwag → Poliwhirl → Poliwrath/Politoed)
- Ensure middle evolution is properly displayed in branching evolution chains

### Documentation
- Create comprehensive `LANGUAGE_IMPLEMENTATION.md` guide
- Update CLAUDE.md with latest changes

## Testing
- ✅ Type checking passes
- ✅ Lint checking passes
- ✅ All languages display correctly
- ✅ Evolution chains render properly
- ✅ Copyright notices appear in all appropriate locations

🤖 Generated with [Claude Code](https://claude.ai/code)