### PR TITLE
feat: add Spanish language support and native language display names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,13 @@ pokemon-pokedex/
 ### Language Implementation
 @docs/LANGUAGE_IMPLEMENTATION.md
 
+### Supported Languages
+- English (en)
+- Japanese (ja) 
+- Traditional Chinese (zh-Hant)
+- Simplified Chinese (zh-Hans)
+- Spanish (es)
+
 
 
 ## Common Issues & Solutions

--- a/client/app/[lang]/layout.tsx
+++ b/client/app/[lang]/layout.tsx
@@ -7,6 +7,7 @@ export async function generateStaticParams() {
     { lang: "ja" },
     { lang: "zh-Hans" },
     { lang: "zh-Hant" },
+    { lang: "es" },
   ];
 }
 

--- a/client/app/[lang]/pokemon/[id]/page.tsx
+++ b/client/app/[lang]/pokemon/[id]/page.tsx
@@ -32,7 +32,7 @@ interface PokemonDetailPageProps {
 // Generate static params for SSG with generational build support
 export async function generateStaticParams() {
   const paths = [];
-  const languages = ["en", "ja", "zh-Hans", "zh-Hant"];
+  const languages = ["en", "ja", "zh-Hans", "zh-Hant", "es"];
 
   // Check environment variables for generational build control
   const enableGenerationalBuild =

--- a/client/lib/data/languages.ts
+++ b/client/lib/data/languages.ts
@@ -23,4 +23,5 @@ export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { value: "ja", labelKey: "japanese", flag: "🇯🇵" },
   { value: "zh-Hans", labelKey: "simplifiedChinese", flag: "🇨🇳" },
   { value: "zh-Hant", labelKey: "traditionalChinese", flag: "🇹🇼" },
+  { value: "es", labelKey: "spanish", flag: "🇪🇸" },
 ];

--- a/client/lib/dictionaries.ts
+++ b/client/lib/dictionaries.ts
@@ -1,4 +1,4 @@
-export type Locale = "en" | "ja" | "zh-Hans" | "zh-Hant";
+export type Locale = "en" | "ja" | "zh-Hans" | "zh-Hant" | "es";
 
 // Dictionary type definition
 export interface Dictionary {
@@ -77,6 +77,11 @@ export interface Dictionary {
       unknown: string;
       evolutionChainError: string;
       movesError: string;
+      genericError: string;
+      networkError: string;
+      serverError: string;
+      notFoundError: string;
+      validationError: string;
     };
     common: {
       loading: string;
@@ -99,6 +104,7 @@ export interface Dictionary {
       gameHistory: string;
       sprites: string;
       evolutionChain: string;
+      evolutionOptions: string;
       type: string;
       category: string;
       power: string;
@@ -469,6 +475,7 @@ export interface Dictionary {
     description: string;
     homeTitle: string;
     homeDescription: string;
+    listDescription: string;
     pokemonTitle: string;
     pokemonDescription: string;
     pokemonDescriptionShort: string;
@@ -489,7 +496,7 @@ export interface Dictionary {
 export const getLocaleFromPathname = (pathname: string): Locale => {
   const segments = pathname.split("/");
   const locale = segments[1] as Locale;
-  return locale && ["en", "ja", "zh-Hans", "zh-Hant"].includes(locale)
+  return locale && ["en", "ja", "zh-Hans", "zh-Hant", "es"].includes(locale)
     ? locale
     : "en";
 };
@@ -503,7 +510,7 @@ export const generateAlternateLanguageUrl = (
 
   if (
     currentLocale &&
-    ["en", "ja", "zh-Hans", "zh-Hant"].includes(currentLocale)
+    ["en", "ja", "zh-Hans", "zh-Hant", "es"].includes(currentLocale)
   ) {
     segments[1] = newLocale;
     return segments.join("/");

--- a/client/lib/dictionaries/en.json
+++ b/client/lib/dictionaries/en.json
@@ -231,14 +231,14 @@
     },
     "language": {
       "english": "English",
-      "japanese": "Japanese",
-      "traditionalChinese": "Traditional Chinese",
-      "simplifiedChinese": "Simplified Chinese",
-      "spanish": "Spanish",
-      "korean": "Korean",
-      "french": "French",
-      "italian": "Italian",
-      "german": "German",
+      "japanese": "日本語",
+      "traditionalChinese": "繁體中文",
+      "simplifiedChinese": "简体中文",
+      "spanish": "Español",
+      "korean": "한국어",
+      "french": "Français",
+      "italian": "Italiano",
+      "german": "Deutsch",
       "toggle": "Toggle language"
     },
     "sandbox": {

--- a/client/lib/dictionaries/es.json
+++ b/client/lib/dictionaries/es.json
@@ -67,14 +67,22 @@
       "loadingPokedex": "Cargando Pokédex..."
     },
     "error": {
-      "title": "Algo salió mal",
+      "title": "Error al cargar Pokémon",
       "tryAgain": "Intentar de nuevo",
       "pokemonNotFound": "Pokémon no encontrado",
       "goHome": "Ir al inicio",
-      "unknown": "Error desconocido"
+      "unknown": "Desconocido",
+      "evolutionChainError": "Error al cargar datos de evolución",
+      "movesError": "Error al cargar datos de movimientos",
+      "genericError": "Ocurrió un error",
+      "networkError": "Error de red",
+      "serverError": "Error del servidor",
+      "notFoundError": "Recurso no encontrado",
+      "validationError": "Datos inválidos"
     },
     "common": {
-      "loading": "Cargando..."
+      "loading": "Cargando",
+      "tagline": "Base de datos no oficial de Pokémon"
     },
     "notFound": {
       "title": "Página no encontrada",
@@ -93,6 +101,7 @@
       "gameHistory": "Historia de Juegos",
       "sprites": "Imágenes",
       "evolutionChain": "Cadena Evolutiva",
+      "evolutionOptions": "Opciones de Evolución",
       "type": "Tipo",
       "category": "Categoría",
       "power": "Poder",
@@ -227,9 +236,9 @@
       "simplifiedChinese": "简体中文",
       "spanish": "Español",
       "korean": "한국어",
-      "french": "Francés",
+      "french": "Français",
       "italian": "Italiano",
-      "german": "Alemán",
+      "german": "Deutsch",
       "toggle": "Cambiar idioma"
     },
     "sandbox": {
@@ -247,6 +256,7 @@
       "games": "No hay datos de juegos disponibles",
       "sprites": "No hay sprites disponibles",
       "evolution": "No hay datos de evolución disponibles",
+      "evolutionSoon": "Los datos de evolución estarán disponibles pronto",
       "abilities": "No hay habilidades disponibles",
       "general": "No hay datos disponibles"
     },
@@ -443,8 +453,9 @@
   "meta": {
     "title": "Pokédex - Explora el Mundo Pokémon",
     "description": "Descubre todos los Pokémon con nuestro Pokédex completo. Explora estadísticas, tipos, habilidades, movimientos y cadenas evolutivas de todas las generaciones.",
-    "homeTitle": "Pokédex - Base de Datos Completa de Pokémon",
-    "homeDescription": "Tu Pokédex definitiva con información completa de todas las generaciones. Explora estadísticas detalladas, tipos, habilidades y evoluciones de más de 1000 Pokémon.",
+    "homeTitle": "Pokédex No Oficial | Base de Datos Completa Multi-Generacional de Pokémon",
+    "homeDescription": "Base de datos completa no oficial de Pokémon con más de 1302 Pokémon, estadísticas detalladas, arte oficial, efectividad de tipos, cadenas evolutivas y conjuntos de movimientos. Cobertura completa de Generación 1 a 9. Este es un sitio de fans no afiliado con Nintendo.",
+    "listDescription": "Explora todos los Pokémon de la región {{region}}. Filtra por tipo, busca por nombre y descubre información detallada de cada Pokémon incluyendo estadísticas, cadenas evolutivas y movimientos.",
     "pokemonTitle": "{{name}} (#{{id}}) - Pokémon {{type}} | Pokédex",
     "pokemonDescription": "{{name}} es un Pokémon tipo {{type}} con {{hp}} PS, {{attack}} de Ataque y {{defense}} de Defensa. {{description}}",
     "pokemonDescriptionShort": "{{name}} - Pokémon tipo {{type}} de la Generación {{generation}}. Altura: {{height}}m, Peso: {{weight}}kg.",
@@ -452,6 +463,12 @@
     "homeKeywords": "Pokédex, Pokémon, estadísticas, tipos, habilidades, movimientos, evolución, generaciones, base de datos",
     "pokemonImageAlt": "Arte oficial de {{name}} - Pokémon {{type}}",
     "fallbackImageAlt": "Imagen de Pokémon",
-    "locale": "es"
+    "locale": "es_ES"
+  },
+  "footer": {
+    "copyright": "Pokémon © 1995-{{currentYear}} Nintendo/Creatures Inc./GAME FREAK inc.",
+    "trademark": "Pokémon y los nombres de los personajes Pokémon son marcas registradas de Nintendo.",
+    "disclaimer": "Este es un sitio no oficial, no comercial, hecho por fans, no afiliado con Nintendo, Creatures Inc., o GAME FREAK inc.",
+    "dataSource": "Fuente de datos:"
   }
 }

--- a/client/lib/dictionaries/ja.json
+++ b/client/lib/dictionaries/ja.json
@@ -236,7 +236,7 @@
       "simplifiedChinese": "简体中文",
       "spanish": "Español",
       "korean": "한국어",
-      "french": "フランス語",
+      "french": "Français",
       "italian": "Italiano",
       "german": "Deutsch",
       "toggle": "言語の切り替え"

--- a/client/lib/dictionaries/zh-Hans.json
+++ b/client/lib/dictionaries/zh-Hans.json
@@ -235,9 +235,9 @@
       "simplifiedChinese": "简体中文",
       "spanish": "Español",
       "korean": "한국어",
-      "french": "法语",
+      "french": "Français",
       "italian": "Italiano",
-      "german": "德语",
+      "german": "Deutsch",
       "toggle": "切换语言"
     },
     "sandbox": {

--- a/client/lib/dictionaries/zh-Hant.json
+++ b/client/lib/dictionaries/zh-Hant.json
@@ -235,9 +235,9 @@
       "simplifiedChinese": "简体中文",
       "spanish": "Español",
       "korean": "한국어",
-      "french": "法語",
+      "french": "Français",
       "italian": "Italiano",
-      "german": "德語",
+      "german": "Deutsch",
       "toggle": "切換語言"
     },
     "sandbox": {

--- a/client/lib/get-dictionary.ts
+++ b/client/lib/get-dictionary.ts
@@ -8,6 +8,7 @@ const dictionaries = {
     import("./dictionaries/zh-Hans.json").then((module) => module.default),
   "zh-Hant": () =>
     import("./dictionaries/zh-Hant.json").then((module) => module.default),
+  es: () => import("./dictionaries/es.json").then((module) => module.default),
 };
 
 export const getDictionary = async (locale: Locale): Promise<Dictionary> => {

--- a/client/lib/languageStorage.ts
+++ b/client/lib/languageStorage.ts
@@ -18,7 +18,8 @@ export function getStoredLanguage(): Locale | null {
       (stored === "en" ||
         stored === "ja" ||
         stored === "zh-Hans" ||
-        stored === "zh-Hant")
+        stored === "zh-Hant" ||
+        stored === "es")
     ) {
       return stored as Locale;
     }
@@ -84,7 +85,8 @@ export function getLanguageFromCookie(cookieString: string): Locale | null {
       value === "en" ||
       value === "ja" ||
       value === "zh-Hans" ||
-      value === "zh-Hant"
+      value === "zh-Hant" ||
+      value === "es"
     ) {
       return value as Locale;
     }

--- a/client/lib/pokemonUtils.ts
+++ b/client/lib/pokemonUtils.ts
@@ -211,13 +211,17 @@ export function getPokemonName(
 
     // Use species data for localized names
     if (
-      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      (language === "ja" ||
+        language === "zh-Hans" ||
+        language === "zh-Hant" ||
+        language === "es") &&
       pokemon.species?.names
     ) {
       const languageCodes = {
         ja: ["ja", "ja-Hrkt"],
         "zh-Hans": ["zh-Hans"],
         "zh-Hant": ["zh-Hant"],
+        es: ["es"],
       };
 
       const targetCodes = languageCodes[
@@ -294,7 +298,10 @@ export function getPokemonName(
 
     // Handle non-English languages with species names
     if (
-      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      (language === "ja" ||
+        language === "zh-Hans" ||
+        language === "zh-Hant" ||
+        language === "es") &&
       pokemon.species?.names
     ) {
       // Map language codes for PokeAPI
@@ -302,6 +309,7 @@ export function getPokemonName(
         ja: ["ja", "ja-Hrkt"],
         "zh-Hans": ["zh-Hans"],
         "zh-Hant": ["zh-Hant"],
+        es: ["es"],
       };
 
       const targetCodes = languageCodes[
@@ -401,7 +409,10 @@ export function getPokemonName(
 
   // For non-variant Pokemon
   if (
-    (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+    (language === "ja" ||
+      language === "zh-Hans" ||
+      language === "zh-Hant" ||
+      language === "es") &&
     pokemon.species?.names
   ) {
     // Map language codes for PokeAPI
@@ -409,6 +420,7 @@ export function getPokemonName(
       ja: ["ja", "ja-Hrkt"],
       "zh-Hans": ["zh-Hans"],
       "zh-Hant": ["zh-Hant"],
+      es: ["es"],
     };
 
     const targetCodes = languageCodes[
@@ -445,7 +457,10 @@ export function getEvolutionPokemonName(
 
     // Handle non-English languages with species names
     if (
-      (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+      (language === "ja" ||
+        language === "zh-Hans" ||
+        language === "zh-Hant" ||
+        language === "es") &&
       evolutionDetail.species?.names
     ) {
       // Map language codes for PokeAPI
@@ -453,6 +468,7 @@ export function getEvolutionPokemonName(
         ja: ["ja", "ja-Hrkt"],
         "zh-Hans": ["zh-Hans"],
         "zh-Hant": ["zh-Hant"],
+        es: ["es"],
       };
 
       const targetCodes = languageCodes[
@@ -511,7 +527,10 @@ export function getEvolutionPokemonName(
 
   // For non-variant Pokemon
   if (
-    (language === "ja" || language === "zh-Hans" || language === "zh-Hant") &&
+    (language === "ja" ||
+      language === "zh-Hans" ||
+      language === "zh-Hant" ||
+      language === "es") &&
     evolutionDetail.species?.names
   ) {
     // Map language codes for PokeAPI
@@ -519,6 +538,7 @@ export function getEvolutionPokemonName(
       ja: ["ja", "ja-Hrkt"],
       "zh-Hans": ["zh-Hans"],
       "zh-Hant": ["zh-Hant"],
+      es: ["es"],
     };
 
     const targetCodes = languageCodes[
@@ -557,6 +577,7 @@ export function getPokemonDescription(
     ja: ["ja", "ja-Hrkt"],
     "zh-Hans": ["zh-Hans"],
     "zh-Hant": ["zh-Hant"],
+    es: ["es"],
   };
 
   const targetCodes = languageMap[language] || ["en"];
@@ -597,6 +618,7 @@ function getGenusFallback(language: Locale): string {
     ja: "ポケモン",
     "zh-Hans": "宝可梦",
     "zh-Hant": "寶可夢",
+    es: "Pokémon",
   };
 
   return fallbackTexts[language] || "Pokémon";
@@ -618,6 +640,7 @@ export function getPokemonGenus(pokemon: Pokemon, language: Locale): string {
     ja: ["ja", "ja-Hrkt"],
     "zh-Hans": ["zh-Hans"],
     "zh-Hant": ["zh-Hant"],
+    es: ["es"],
   };
 
   const targetCodes = languageMap[language] || ["en"];
@@ -1111,6 +1134,7 @@ export function getMoveFlavorText(move: Move, language: Locale): string {
     ja: ["ja", "ja-Hrkt"],
     "zh-Hans": ["zh-Hans"],
     "zh-Hant": ["zh-Hant"],
+    es: ["es"],
   };
 
   const targetCodes = languageMap[language] || ["en"];

--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getLanguageFromCookie } from "@/lib/languageStorage";
 
-const locales = ["en", "ja", "zh-Hans", "zh-Hant"];
+const locales = ["en", "ja", "zh-Hans", "zh-Hant", "es"];
 const defaultLocale = "en";
 
 // Check User-Agent for language indicators
@@ -72,6 +72,31 @@ function getUserAgentLanguage(request: NextRequest): string | null {
   for (const indicator of simplifiedChineseIndicators) {
     if (userAgentLower.includes(indicator.toLowerCase())) {
       return "zh-Hans";
+    }
+  }
+
+  // Check for Spanish language indicators
+  const spanishIndicators = [
+    "es",
+    "es-es",
+    "es-mx",
+    "es-ar",
+    "es-co",
+    "es-cl",
+    "spanish",
+    "español",
+    "spain",
+    "españa",
+    "mexico",
+    "méxico",
+    "argentina",
+    "colombia",
+    "chile",
+  ];
+
+  for (const indicator of spanishIndicators) {
+    if (userAgentLower.includes(indicator.toLowerCase())) {
+      return "es";
     }
   }
 


### PR DESCRIPTION
## Summary
- ✨ Added complete Spanish language support
- 🌐 Updated language display names to show in their native form
- 🎨 Improved user experience for language selection

## Changes Made

### Spanish Language Implementation
- Added complete Spanish translations (`es.json`) for all UI elements
- Configured Spanish locale in TypeScript type definitions
- Updated middleware to detect Spanish language from User-Agent
- Added Spanish to static generation parameters for SSG
- Updated all utility functions to support Spanish locale

### Native Language Display Names
Updated all dictionary files to display language names in their native form:
- English → English
- Japanese → 日本語
- Traditional Chinese → 繁體中文
- Simplified Chinese → 简体中文
- Spanish → Español
- Korean → 한국어
- French → Français
- Italian → Italiano
- German → Deutsch

This provides a more intuitive language selection experience where users can immediately recognize their language.

### Technical Details
- Updated `Locale` type to include "es"
- Modified middleware Spanish detection indicators
- Added Spanish language mapping in `pokemonUtils.ts`
- Updated CLAUDE.md with supported languages list
- All type checking passes successfully

## Testing
- [x] Type checking passes
- [x] Spanish translations display correctly
- [x] Language switching works properly
- [x] Native language names display in language selector

🤖 Generated with [Claude Code](https://claude.ai/code)